### PR TITLE
Corrección de versiones y ajuste visual de título de navegación

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace 'com.misw.app'
-    compileSdk 37
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.misw.app"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -11,6 +11,7 @@
         android:id="@+id/appBarLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:fitsSystemWindows="true"
         app:layout_constraintTop_toTopOf="parent">
 
         <com.google.android.material.appbar.MaterialToolbar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.2.1"
+agp = "9.1.1"
 appcompat = "1.7.1"
 constraintlayout = "2.2.1"
 coreKtx = "1.18.0"


### PR DESCRIPTION
- Se corrigen las versiones de compileSdk y agp para que la app se pueda compilar
- Se corrige el título de navegación, pues estaba sobrelapando la barra de notificaciones:

| ANTES | DESPUÉS |
|---------|------------|
| <img width="300" alt="antes" src="https://github.com/user-attachments/assets/374d4a67-8adf-4d3d-a265-977c474885d6" /> | <img width="300" alt="despues" src="https://github.com/user-attachments/assets/f59b873d-8fbc-4bd5-9f43-98ff55bfe550" /> |
