### PR TITLE
Botón de crear álbum con navegación

### DIFF
--- a/app/src/main/java/com/misw/app/ui/albums/AlbumCreateFragment.kt
+++ b/app/src/main/java/com/misw/app/ui/albums/AlbumCreateFragment.kt
@@ -1,0 +1,29 @@
+package com.misw.app.ui.albums
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import com.misw.app.databinding.FragmentAlbumCreateBinding
+import com.misw.app.viewmodel.AlbumCreateViewModel
+
+class AlbumCreateFragment : Fragment() {
+
+    private val viewModel: AlbumCreateViewModel by viewModels()
+    private var _binding : FragmentAlbumCreateBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentAlbumCreateBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/misw/app/ui/albums/AlbumListFragment.kt
+++ b/app/src/main/java/com/misw/app/ui/albums/AlbumListFragment.kt
@@ -4,9 +4,14 @@ import android.content.res.ColorStateList
 import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import androidx.core.content.ContextCompat
+import androidx.core.view.MenuProvider
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -34,6 +39,20 @@ class AlbumListFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        requireActivity().addMenuProvider(object : MenuProvider {
+            override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                menuInflater.inflate(R.menu.menu_album_list, menu)
+                val item = menu.findItem(R.id.action_create)
+                item.actionView?.findViewById<Button>(R.id.buttonCreate)?.setOnClickListener {
+                    findNavController().navigate(R.id.action_albumsListFragment_to_albumCreateFragment)
+                }
+            }
+
+            override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                return false
+            }
+        }, viewLifecycleOwner)
 
         setupRecyclerView()
         setupControls()

--- a/app/src/main/java/com/misw/app/viewmodel/AlbumCreateViewModel.kt
+++ b/app/src/main/java/com/misw/app/viewmodel/AlbumCreateViewModel.kt
@@ -1,0 +1,49 @@
+package com.misw.app.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
+import com.misw.app.R
+import com.misw.app.repository.album.AlbumRepository
+import com.misw.app.repository.album.AlbumRepositoryImpl
+import kotlinx.coroutines.launch
+
+class AlbumCreateViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val repository : AlbumRepository = AlbumRepositoryImpl(application)
+
+    private val _genres = MutableLiveData<List<String>>()
+    val genres: LiveData<List<String>> get() = _genres
+
+    private val _recordLabels = MutableLiveData<List<String>>()
+    val recordLabels: LiveData<List<String>> get() = _recordLabels
+
+    private val _error = MutableLiveData<String?>()
+    val error: LiveData<String?> get() = _error
+
+    private val _isLoading = MutableLiveData<Boolean>()
+    val isLoading: LiveData<Boolean> get() = _isLoading
+
+
+    init {
+        fetchData()
+    }
+
+    private fun fetchData() {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _error.value = null
+            try {
+                _genres.value = repository.getGenres()
+                _recordLabels.value = repository.getRecordLabels()
+            } catch (_: Exception) {
+                _error.value = getApplication<Application>().getString(R.string.error_loading_content)
+            }
+            finally {
+                _isLoading.value = false
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/pill_create_button.xml
+++ b/app/src/main/res/drawable/pill_create_button.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="8dp" />
+    <solid android:color="@color/wild_strawberry"/>
+</shape>

--- a/app/src/main/res/layout/fragment_album_create.xml
+++ b/app/src/main/res/layout/fragment_album_create.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="Hola mundo" />
+
+</layout>

--- a/app/src/main/res/layout/toolbar_button_create.xml
+++ b/app/src/main/res/layout/toolbar_button_create.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/buttonCreate"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end|center_vertical"
+        android:layout_marginEnd="20dp"
+        android:minWidth="0dp"
+        android:minHeight="0dp"
+        android:insetTop="0dp"
+        android:insetBottom="0dp"
+        android:paddingHorizontal="15dp"
+        android:paddingVertical="4dp"
+        android:text="@string/album_create_button_text"
+        android:textSize="16sp"
+        android:textColor="@color/white"
+        android:foreground="?attr/selectableItemBackground"
+        android:background="@drawable/pill_create_button"
+        android:textAllCaps="false"/>
+</FrameLayout>

--- a/app/src/main/res/menu/menu_album_list.xml
+++ b/app/src/main/res/menu/menu_album_list.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:title=""
+        android:id="@+id/action_create"
+        app:showAsAction="always"
+        app:actionLayout="@layout/toolbar_button_create"/>
+</menu>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -29,6 +29,9 @@
         <action
             android:id="@+id/action_albumsListFragment_to_albumDetailFragment"
             app:destination="@id/albumDetailFragment" />
+        <action
+            android:id="@+id/action_albumsListFragment_to_albumCreateFragment"
+            app:destination="@id/albumCreateFragment" />
     </fragment>
 
     <fragment
@@ -49,6 +52,13 @@
         <action
             android:id="@+id/action_musicianListFragment_to_musicianDetailFragment"
             app:destination="@id/musicianDetailFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/albumCreateFragment"
+        android:name="com.misw.app.ui.albums.AlbumCreateFragment"
+        android:label="Crear álbum"
+        tools:layout="@layout/fragment_album_create">
     </fragment>
 
     <fragment

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,4 +29,5 @@
     <string name="track_number">%s</string>
     <string name="tracklist">Tracklist</string>
     <string name="trophy_description">ícono de trofeo</string>
+    <string name="album_create_button_text">Crear</string>
 </resources>


### PR DESCRIPTION
Se añade el botón para crear un álbum, junto con la navegación hacia la vista correspondiente, que por el momento está vacía. El botón se tuvo que dejar en la esquina derecha porque para dejarla al lado del título como está en el mockup, habría que crear un toolbar personalizado. Puede ser un nice-to-have para después, pero personalmente creo que tiene más sentido dejarlo en la esquina.

<img height="500" alt="Captura de pantalla 2026-05-12 234439" src="https://github.com/user-attachments/assets/2d46bde2-f42a-4a7d-9543-2ba28c27a114" />
