### PR TITLE
Modales y mensajes de confirmación para asociación de canción

### DIFF
--- a/app/src/androidTest/java/com/misw/app/TrackAssociateTest.kt
+++ b/app/src/androidTest/java/com/misw/app/TrackAssociateTest.kt
@@ -88,6 +88,5 @@ class TrackAssociateTest {
     fun testAssociateTracksButtonNavigatesToAssociateScreen() {
         navigateToAlbumDetail()
         onView(withId(R.id.btnAssociateTracks)).perform(click())
-        onView(withId(R.id.tvAssociateTrackTitle)).check(matches(isDisplayed()))
     }
 }

--- a/app/src/androidTest/java/com/misw/app/TrackAssociateTest.kt
+++ b/app/src/androidTest/java/com/misw/app/TrackAssociateTest.kt
@@ -14,7 +14,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.recyclerview.widget.RecyclerView
-import com.misw.app.BuildConfig
 import com.misw.app.network.CacheManager
 import com.misw.app.network.EspressoIdlingResource
 import com.misw.app.network.RetrofitClient
@@ -31,7 +30,7 @@ import org.junit.runner.RunWith
 
 @LargeTest
 @RunWith(AndroidJUnit4::class)
-class HU08TrackAssociateTest {
+class TrackAssociateTest {
 
     @Rule
     @JvmField

--- a/app/src/androidTest/java/com/misw/app/TrackAssociateTest.kt
+++ b/app/src/androidTest/java/com/misw/app/TrackAssociateTest.kt
@@ -88,5 +88,6 @@ class TrackAssociateTest {
     fun testAssociateTracksButtonNavigatesToAssociateScreen() {
         navigateToAlbumDetail()
         onView(withId(R.id.btnAssociateTracks)).perform(click())
+        onView(withText("Asociar canción")).check(matches(isDisplayed()))
     }
 }

--- a/app/src/androidTest/java/com/misw/app/TrackAssociateViewTest.kt
+++ b/app/src/androidTest/java/com/misw/app/TrackAssociateViewTest.kt
@@ -277,7 +277,7 @@ class TrackAssociateViewTest {
         onView(withId(R.id.etTrackName)).perform(typeText("My Track"))
         onView(withId(R.id.etMinutos)).perform(typeText("abc"))
         onView(withId(R.id.etSegundos)).perform(typeText("45"))
-
+        onView(isRoot()).perform(closeSoftKeyboard())
 
         // Click associate button
         onView(withId(R.id.btnAssociate)).perform(click())

--- a/app/src/androidTest/java/com/misw/app/TrackAssociateViewTest.kt
+++ b/app/src/androidTest/java/com/misw/app/TrackAssociateViewTest.kt
@@ -10,6 +10,7 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.espresso.matcher.ViewMatchers.withHint
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
@@ -27,6 +28,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
+import androidx.test.espresso.matcher.ViewMatchers.isRoot
 
 @LargeTest
 @RunWith(AndroidJUnit4::class)
@@ -86,13 +89,6 @@ class TrackAssociateViewTest {
     }
 
     @Test
-    fun testTrackAssociateScreenDisplaysTitle() {
-        navigateToTrackAssociateScreen()
-        onView(withId(R.id.tvAssociateTrackTitle)).check(matches(isDisplayed()))
-        onView(withId(R.id.tvAssociateTrackTitle)).check(matches(withText("Asociar track")))
-    }
-
-    @Test
     fun testTrackAssociateScreenDisplaysInputFields() {
         navigateToTrackAssociateScreen()
         onView(withId(R.id.etTrackName)).check(matches(isDisplayed()))
@@ -138,9 +134,13 @@ class TrackAssociateViewTest {
         onView(withId(R.id.etTrackName)).perform(typeText("Test Track"))
         onView(withId(R.id.etMinutos)).perform(typeText("3"))
         onView(withId(R.id.etSegundos)).perform(typeText("45"))
+        onView(isRoot()).perform(closeSoftKeyboard())
 
         // Click associate button
         onView(withId(R.id.btnAssociate)).perform(click())
+
+        // Click 'Sí' on modal
+        onView(withText("Sí")).perform(click())
 
         // Should navigate back to album detail
         onView(withId(R.id.tvTrackCount)).check(matches(isDisplayed()))
@@ -181,12 +181,13 @@ class TrackAssociateViewTest {
         navigateToTrackAssociateScreen()
 
         // Verify we're on the associate track screen
-        onView(withId(R.id.tvAssociateTrackTitle)).check(matches(isDisplayed()))
+        onView(withText("Asociar canción")).check(matches(isDisplayed()))
 
         // Fill in all track details
         onView(withId(R.id.etTrackName)).perform(typeText("Bohemian Rhapsody"))
         onView(withId(R.id.etMinutos)).perform(typeText("5"))
         onView(withId(R.id.etSegundos)).perform(typeText("55"))
+        onView(isRoot()).perform(closeSoftKeyboard())
 
         // Verify data was entered
         onView(withId(R.id.etTrackName)).check(matches(withText("Bohemian Rhapsody")))
@@ -195,6 +196,9 @@ class TrackAssociateViewTest {
 
         // Click associate button
         onView(withId(R.id.btnAssociate)).perform(click())
+
+        // Click 'Sí' on modal
+        onView(withText("Sí")).perform(click())
 
         // Should return to album detail view with track count displayed
         onView(withId(R.id.tvTrackCount)).check(matches(isDisplayed()))
@@ -207,12 +211,13 @@ class TrackAssociateViewTest {
         // Leave track name empty and fill other fields
         onView(withId(R.id.etMinutos)).perform(typeText("3"))
         onView(withId(R.id.etSegundos)).perform(typeText("45"))
+        onView(isRoot()).perform(closeSoftKeyboard())
 
         // Click associate button
         onView(withId(R.id.btnAssociate)).perform(click())
 
         // Should stay on the same screen (validation error shown in toast)
-        onView(withId(R.id.tvAssociateTrackTitle)).check(matches(isDisplayed()))
+        onView(withText("Asociar canción")).check(matches(isDisplayed()))
     }
 
     @Test
@@ -222,12 +227,13 @@ class TrackAssociateViewTest {
         // Fill track name but leave minutes empty
         onView(withId(R.id.etTrackName)).perform(typeText("My Track"))
         onView(withId(R.id.etSegundos)).perform(typeText("45"))
+        onView(isRoot()).perform(closeSoftKeyboard())
 
         // Click associate button
         onView(withId(R.id.btnAssociate)).perform(click())
 
         // Should stay on the same screen
-        onView(withId(R.id.tvAssociateTrackTitle)).check(matches(isDisplayed()))
+        onView(withText("Asociar canción")).check(matches(isDisplayed()))
     }
 
     @Test
@@ -237,12 +243,13 @@ class TrackAssociateViewTest {
         // Fill track name and minutes but leave seconds empty
         onView(withId(R.id.etTrackName)).perform(typeText("My Track"))
         onView(withId(R.id.etMinutos)).perform(typeText("3"))
+        onView(isRoot()).perform(closeSoftKeyboard())
 
         // Click associate button
         onView(withId(R.id.btnAssociate)).perform(click())
 
         // Should stay on the same screen
-        onView(withId(R.id.tvAssociateTrackTitle)).check(matches(isDisplayed()))
+        onView(withText("Asociar canción")).check(matches(isDisplayed()))
     }
 
     @Test
@@ -253,12 +260,13 @@ class TrackAssociateViewTest {
         onView(withId(R.id.etTrackName)).perform(typeText("My Track"))
         onView(withId(R.id.etMinutos)).perform(typeText("3"))
         onView(withId(R.id.etSegundos)).perform(typeText("75"))
+        onView(isRoot()).perform(closeSoftKeyboard())
 
         // Click associate button
         onView(withId(R.id.btnAssociate)).perform(click())
 
         // Should stay on the same screen
-        onView(withId(R.id.tvAssociateTrackTitle)).check(matches(isDisplayed()))
+        onView(withText("Asociar canción")).check(matches(isDisplayed()))
     }
 
     @Test
@@ -270,11 +278,12 @@ class TrackAssociateViewTest {
         onView(withId(R.id.etMinutos)).perform(typeText("abc"))
         onView(withId(R.id.etSegundos)).perform(typeText("45"))
 
+
         // Click associate button
         onView(withId(R.id.btnAssociate)).perform(click())
 
         // Should stay on the same screen
-        onView(withId(R.id.tvAssociateTrackTitle)).check(matches(isDisplayed()))
+        onView(withText("Asociar canción")).check(matches(isDisplayed()))
     }
 
     @Test
@@ -285,9 +294,13 @@ class TrackAssociateViewTest {
         onView(withId(R.id.etTrackName)).perform(typeText("Silent Track"))
         onView(withId(R.id.etMinutos)).perform(typeText("0"))
         onView(withId(R.id.etSegundos)).perform(typeText("0"))
+        onView(isRoot()).perform(closeSoftKeyboard())
 
         // Click associate button
         onView(withId(R.id.btnAssociate)).perform(click())
+
+        // Click 'Sí' on modal
+        onView(withText("Sí")).perform(click())
 
         // Should return to album detail
         onView(withId(R.id.tvTrackCount)).check(matches(isDisplayed()))
@@ -301,9 +314,13 @@ class TrackAssociateViewTest {
         onView(withId(R.id.etTrackName)).perform(typeText("Track"))
         onView(withId(R.id.etMinutos)).perform(typeText("10"))
         onView(withId(R.id.etSegundos)).perform(typeText("59"))
+        onView(isRoot()).perform(closeSoftKeyboard())
 
         // Click associate button
         onView(withId(R.id.btnAssociate)).perform(click())
+
+        // Click 'Sí' on modal
+        onView(withText("Sí")).perform(click())
 
         // Should return to album detail
         onView(withId(R.id.tvTrackCount)).check(matches(isDisplayed()))
@@ -317,9 +334,13 @@ class TrackAssociateViewTest {
         onView(withId(R.id.etTrackName)).perform(typeText("Track"))
         onView(withId(R.id.etMinutos)).perform(typeText("5"))
         onView(withId(R.id.etSegundos)).perform(typeText("9"))
+        onView(isRoot()).perform(closeSoftKeyboard())
 
         // Click associate button
         onView(withId(R.id.btnAssociate)).perform(click())
+
+        // Click 'Sí' on modal
+        onView(withText("Sí")).perform(click())
 
         // Should return to album detail (duration will be formatted as 05:09)
         onView(withId(R.id.tvTrackCount)).check(matches(isDisplayed()))
@@ -335,9 +356,13 @@ class TrackAssociateViewTest {
         onView(withId(R.id.etTrackName)).perform(typeText(longTrackName))
         onView(withId(R.id.etMinutos)).perform(typeText("8"))
         onView(withId(R.id.etSegundos)).perform(typeText("30"))
+        onView(isRoot()).perform(closeSoftKeyboard())
 
         // Click associate button
         onView(withId(R.id.btnAssociate)).perform(click())
+
+        // Click 'Sí' on modal
+        onView(withText("Sí")).perform(click())
 
         // Should return to album detail
         onView(withId(R.id.tvTrackCount)).check(matches(isDisplayed()))
@@ -351,11 +376,13 @@ class TrackAssociateViewTest {
         onView(withId(R.id.etTrackName)).perform(typeText("First Track"))
         onView(withId(R.id.etMinutos)).perform(typeText("3"))
         onView(withId(R.id.etSegundos)).perform(typeText("30"))
+        onView(isRoot()).perform(closeSoftKeyboard())
 
         // Clear and re-enter different data
         onView(withId(R.id.etTrackName)).perform(clearText(), typeText("Second Track"))
         onView(withId(R.id.etMinutos)).perform(clearText(), typeText("4"))
         onView(withId(R.id.etSegundos)).perform(clearText(), typeText("45"))
+        onView(isRoot()).perform(closeSoftKeyboard())
 
         // Verify new data
         onView(withId(R.id.etTrackName)).check(matches(withText("Second Track")))
@@ -364,6 +391,9 @@ class TrackAssociateViewTest {
 
         // Click associate
         onView(withId(R.id.btnAssociate)).perform(click())
+
+        // Click 'Sí' on modal
+        onView(withText("Sí")).perform(click())
 
         // Should return to album detail
         onView(withId(R.id.tvTrackCount)).check(matches(isDisplayed()))
@@ -377,9 +407,193 @@ class TrackAssociateViewTest {
         onView(withId(R.id.etTrackName)).perform(typeText("Track #1 - Rock's Song"))
         onView(withId(R.id.etMinutos)).perform(typeText("3"))
         onView(withId(R.id.etSegundos)).perform(typeText("45"))
+        onView(isRoot()).perform(closeSoftKeyboard())
 
         // Click associate button
         onView(withId(R.id.btnAssociate)).perform(click())
+
+        // Click 'Sí' on modal
+        onView(withText("Sí")).perform(click())
+
+        // Should return to album detail
+        onView(withId(R.id.tvTrackCount)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testCancelModalIfNameNotEmpty() {
+        navigateToTrackAssociateScreen()
+
+        // Enter track name
+        onView(withId(R.id.etTrackName)).perform(typeText("Song"))
+        onView(isRoot()).perform(closeSoftKeyboard())
+
+        // Click cancel button
+        onView(withId(R.id.btnCancel)).perform(click())
+
+        // Should show cancel modal
+        onView(withText("¿Desea cancelar la asociación de la canción?")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testCancelModalIfMinutesNotEmpty() {
+        navigateToTrackAssociateScreen()
+
+        // Enter track name
+        onView(withId(R.id.etMinutos)).perform(typeText("3"))
+        onView(isRoot()).perform(closeSoftKeyboard())
+
+        // Click cancel button
+        onView(withId(R.id.btnCancel)).perform(click())
+
+        // Should show cancel modal
+        onView(withText("¿Desea cancelar la asociación de la canción?")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testCancelModalIfSecondsNotEmpty() {
+        navigateToTrackAssociateScreen()
+
+        // Enter track name
+        onView(withId(R.id.etSegundos)).perform(typeText("45"))
+        onView(isRoot()).perform(closeSoftKeyboard())
+
+        // Click cancel button
+        onView(withId(R.id.btnCancel)).perform(click())
+
+        // Should show cancel modal
+        onView(withText("¿Desea cancelar la asociación de la canción?")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testCancelModalNoSelected() {
+        navigateToTrackAssociateScreen()
+
+        // Enter track name with special characters
+        onView(withId(R.id.etTrackName)).perform(typeText("Song"))
+        onView(withId(R.id.etMinutos)).perform(typeText("3"))
+        onView(withId(R.id.etSegundos)).perform(typeText("45"))
+        onView(isRoot()).perform(closeSoftKeyboard())
+
+        // Click cancel button
+        onView(withId(R.id.btnCancel)).perform(click())
+
+        // Click 'No' on modal
+        onView(withText("No")).perform(click())
+
+        // Should stay on the same screen
+        onView(withText("Asociar canción")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testCancelModalYesSelected() {
+        navigateToTrackAssociateScreen()
+
+        // Enter track name with special characters
+        onView(withId(R.id.etTrackName)).perform(typeText("Song"))
+        onView(withId(R.id.etMinutos)).perform(typeText("3"))
+        onView(withId(R.id.etSegundos)).perform(typeText("45"))
+        onView(isRoot()).perform(closeSoftKeyboard())
+
+        // Click cancel button
+        onView(withId(R.id.btnCancel)).perform(click())
+
+        // Click 'No' on modal
+        onView(withText("Sí")).perform(click())
+
+        // Should return to album detail
+        onView(withId(R.id.tvTrackCount)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testAlbumDetailModalIfNameNotEmpty() {
+        navigateToTrackAssociateScreen()
+
+        // Enter track name
+        onView(withId(R.id.etTrackName)).perform(typeText("Song"))
+        onView(isRoot()).perform(closeSoftKeyboard())
+
+        // Go back
+        onView(withContentDescription(
+            androidx.appcompat.R.string.abc_action_bar_up_description
+        )).perform(click())
+
+        // Should show album detail modal
+        onView(withText("¿Desea volver al detalle del álbum?")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testAlbumDetailModalIfMinutesNotEmpty() {
+        navigateToTrackAssociateScreen()
+
+        // Enter track name
+        onView(withId(R.id.etMinutos)).perform(typeText("3"))
+        onView(isRoot()).perform(closeSoftKeyboard())
+
+        // Go back
+        onView(withContentDescription(
+            androidx.appcompat.R.string.abc_action_bar_up_description
+        )).perform(click())
+
+        // Should show album detail modal
+        onView(withText("¿Desea volver al detalle del álbum?")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testAlbumDetailModalIfSecondsNotEmpty() {
+        navigateToTrackAssociateScreen()
+
+        // Enter track name
+        onView(withId(R.id.etSegundos)).perform(typeText("45"))
+        onView(isRoot()).perform(closeSoftKeyboard())
+
+        // Go back
+        onView(withContentDescription(
+            androidx.appcompat.R.string.abc_action_bar_up_description
+        )).perform(click())
+
+        // Should show album detail modal
+        onView(withText("¿Desea volver al detalle del álbum?")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testAlbumDetailModalNoSelected() {
+        navigateToTrackAssociateScreen()
+
+        // Enter track name with special characters
+        onView(withId(R.id.etTrackName)).perform(typeText("Song"))
+        onView(withId(R.id.etMinutos)).perform(typeText("3"))
+        onView(withId(R.id.etSegundos)).perform(typeText("45"))
+        onView(isRoot()).perform(closeSoftKeyboard())
+
+        // Go back
+        onView(withContentDescription(
+            androidx.appcompat.R.string.abc_action_bar_up_description
+        )).perform(click())
+
+        // Click 'No' on modal
+        onView(withText("No")).perform(click())
+
+        // Should stay on the same screen
+        onView(withText("Asociar canción")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testAlbumDetailModalYesSelected() {
+        navigateToTrackAssociateScreen()
+
+        // Enter track name with special characters
+        onView(withId(R.id.etTrackName)).perform(typeText("Song"))
+        onView(withId(R.id.etMinutos)).perform(typeText("3"))
+        onView(withId(R.id.etSegundos)).perform(typeText("45"))
+        onView(isRoot()).perform(closeSoftKeyboard())
+
+        // Go back
+        onView(withContentDescription(
+            androidx.appcompat.R.string.abc_action_bar_up_description
+        )).perform(click())
+
+        // Click 'No' on modal
+        onView(withText("Sí")).perform(click())
 
         // Should return to album detail
         onView(withId(R.id.tvTrackCount)).check(matches(isDisplayed()))

--- a/app/src/main/java/com/misw/app/ui/albums/TrackAssociateFragment.kt
+++ b/app/src/main/java/com/misw/app/ui/albums/TrackAssociateFragment.kt
@@ -9,6 +9,9 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.misw.app.databinding.FragmentTrackAssociateBinding
 import com.misw.app.viewmodel.TrackAssociateViewModel
+import androidx.appcompat.app.AlertDialog
+import com.misw.app.R
+import androidx.core.content.ContextCompat
 
 class TrackAssociateFragment : Fragment() {
 
@@ -29,7 +32,26 @@ class TrackAssociateFragment : Fragment() {
 
         // Cancel button
         binding.btnCancel.setOnClickListener {
-            findNavController().popBackStack()
+            val trackName = binding.etTrackName.text.toString()
+            val minutos = binding.etMinutos.text.toString()
+            val segundos = binding.etSegundos.text.toString()
+
+            if (viewModel.areFieldsEmpty(trackName, minutos, segundos)) {
+                findNavController().popBackStack()
+            } else {
+                val dialog = AlertDialog.Builder(requireContext())
+                    .setTitle("¿Desea cancelar la asociación de la canción?")
+                    .setMessage("Esta acción no se puede deshacer")
+                    .setPositiveButton("Sí") {_, _ ->
+                        findNavController().popBackStack()
+                    }
+                    .setNegativeButton("No", null)
+                    .show()
+                dialog.getButton(AlertDialog.BUTTON_POSITIVE)
+                    .setTextColor(ContextCompat.getColor(requireContext(), R.color.prize_pink_text))
+                dialog.getButton(AlertDialog.BUTTON_NEGATIVE)
+                    .setTextColor(ContextCompat.getColor(requireContext(), R.color.prize_pink_text))
+            }
         }
 
         // Associate button
@@ -38,7 +60,23 @@ class TrackAssociateFragment : Fragment() {
             val minutos = binding.etMinutos.text.toString()
             val segundos = binding.etSegundos.text.toString()
 
-            viewModel.associateTrack(albumId, trackName, minutos, segundos)
+            if (viewModel.isFormValid(trackName, minutos, segundos)) {
+                val dialog = AlertDialog.Builder(requireContext())
+                    .setTitle("¿Desea asociar la canción ${trackName}?")
+                    .setMessage("Esta acción no se puede deshacer")
+                    .setPositiveButton("Sí") {_, _ ->
+                        viewModel.associateTrack(albumId, trackName, minutos, segundos)
+                    }
+                    .setNegativeButton("No", null)
+                    .show()
+                dialog.getButton(AlertDialog.BUTTON_POSITIVE)
+                    .setTextColor(ContextCompat.getColor(requireContext(), R.color.prize_pink_text))
+                dialog.getButton(AlertDialog.BUTTON_NEGATIVE)
+                    .setTextColor(ContextCompat.getColor(requireContext(), R.color.prize_pink_text))
+            }
+            else {
+                viewModel.associateTrack(albumId, trackName, minutos, segundos)
+            }
         }
 
         // Observe loading state

--- a/app/src/main/java/com/misw/app/ui/albums/TrackAssociateFragment.kt
+++ b/app/src/main/java/com/misw/app/ui/albums/TrackAssociateFragment.kt
@@ -2,9 +2,12 @@ package com.misw.app.ui.albums
 
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -13,6 +16,8 @@ import com.misw.app.viewmodel.TrackAssociateViewModel
 import androidx.appcompat.app.AlertDialog
 import com.misw.app.R
 import androidx.core.content.ContextCompat
+import androidx.core.widget.doOnTextChanged
+import com.google.android.material.appbar.MaterialToolbar
 
 class TrackAssociateFragment : Fragment() {
 
@@ -30,6 +35,15 @@ class TrackAssociateFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val albumId = arguments?.getInt("album_id") ?: return
+
+        setHasOptionsMenu(true)
+
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    handleBack()
+                }
+            })
 
         // Cancel button
         binding.btnCancel.setOnClickListener {
@@ -99,6 +113,35 @@ class TrackAssociateFragment : Fragment() {
                 Toast.makeText(requireContext(), "Canción asociada exitosamente", Toast.LENGTH_SHORT).show()
                 findNavController().popBackStack()
             }
+        }
+    }
+
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            handleBack()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+
+    private fun handleBack() {
+        val fieldsEmpty = binding.etTrackName.text.isBlank() && binding.etMinutos.text.isBlank() && binding.etSegundos.text.isBlank()
+        if (!fieldsEmpty) {
+            val dialog = AlertDialog.Builder(requireContext())
+                .setTitle("¿Desea volver al detalle del álbum?")
+                .setMessage("Esta eliminará su progreso")
+                .setPositiveButton("Sí") {_, _ ->
+                    findNavController().popBackStack()
+                }
+                .setNegativeButton("No", null)
+                .show()
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE)
+                .setTextColor(ContextCompat.getColor(requireContext(), R.color.prize_pink_text))
+            dialog.getButton(AlertDialog.BUTTON_NEGATIVE)
+                .setTextColor(ContextCompat.getColor(requireContext(), R.color.prize_pink_text))
+        } else {
+            findNavController().popBackStack()
         }
     }
 

--- a/app/src/main/java/com/misw/app/ui/albums/TrackAssociateFragment.kt
+++ b/app/src/main/java/com/misw/app/ui/albums/TrackAssociateFragment.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
-import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -16,8 +15,6 @@ import com.misw.app.viewmodel.TrackAssociateViewModel
 import androidx.appcompat.app.AlertDialog
 import com.misw.app.R
 import androidx.core.content.ContextCompat
-import androidx.core.widget.doOnTextChanged
-import com.google.android.material.appbar.MaterialToolbar
 
 class TrackAssociateFragment : Fragment() {
 
@@ -130,7 +127,7 @@ class TrackAssociateFragment : Fragment() {
         if (!fieldsEmpty) {
             val dialog = AlertDialog.Builder(requireContext())
                 .setTitle("¿Desea volver al detalle del álbum?")
-                .setMessage("Esta eliminará su progreso")
+                .setMessage("Esto eliminará el contenido de los campos que haya llenado")
                 .setPositiveButton("Sí") {_, _ ->
                     findNavController().popBackStack()
                 }

--- a/app/src/main/java/com/misw/app/ui/albums/TrackAssociateFragment.kt
+++ b/app/src/main/java/com/misw/app/ui/albums/TrackAssociateFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -88,13 +89,14 @@ class TrackAssociateFragment : Fragment() {
         // Observe error messages
         viewModel.error.observe(viewLifecycleOwner) { errorMessage ->
             if (!errorMessage.isNullOrEmpty()) {
-                android.widget.Toast.makeText(requireContext(), errorMessage, android.widget.Toast.LENGTH_SHORT).show()
+                Toast.makeText(requireContext(), errorMessage, Toast.LENGTH_SHORT).show()
             }
         }
 
         // Observe association result
         viewModel.associationSuccess.observe(viewLifecycleOwner) { success ->
             if (success) {
+                Toast.makeText(requireContext(), "Canción asociada exitosamente", Toast.LENGTH_SHORT).show()
                 findNavController().popBackStack()
             }
         }

--- a/app/src/main/java/com/misw/app/viewmodel/TrackAssociateViewModel.kt
+++ b/app/src/main/java/com/misw/app/viewmodel/TrackAssociateViewModel.kt
@@ -23,6 +23,19 @@ class TrackAssociateViewModel(application: Application) : AndroidViewModel(appli
     private val _error = MutableLiveData<String?>()
     val error: LiveData<String?> get() = _error
 
+    fun areFieldsEmpty(trackName: String, minutos: String, segundos: String): Boolean {
+        return trackName.isBlank() and minutos.isBlank() and segundos.isBlank()
+    }
+
+    fun isFormValid(trackName: String, minutos: String, segundos: String): Boolean {
+        if (trackName.isBlank()) return false
+        if (minutos.isBlank()) return false
+        if (segundos.isBlank()) return false
+        val minutosInt = minutos.toIntOrNull() ?: return false
+        val segundosInt = segundos.toIntOrNull() ?: return false
+        return segundosInt <= 59
+    }
+
     fun associateTrack(albumId: Int, trackName: String, minutos: String, segundos: String) {
         viewModelScope.launch {
             // Validación de campos

--- a/app/src/main/java/com/misw/app/viewmodel/TrackAssociateViewModel.kt
+++ b/app/src/main/java/com/misw/app/viewmodel/TrackAssociateViewModel.kt
@@ -31,7 +31,7 @@ class TrackAssociateViewModel(application: Application) : AndroidViewModel(appli
         if (trackName.isBlank()) return false
         if (minutos.isBlank()) return false
         if (segundos.isBlank()) return false
-        val minutosInt = minutos.toIntOrNull() ?: return false
+        minutos.toIntOrNull() ?: return false
         val segundosInt = segundos.toIntOrNull() ?: return false
         return segundosInt <= 59
     }

--- a/app/src/main/res/layout/fragment_track_associate.xml
+++ b/app/src/main/res/layout/fragment_track_associate.xml
@@ -41,7 +41,7 @@
                 android:hint="@string/track_name_placeholder"
                 android:inputType="text"
                 android:paddingHorizontal="16dp"
-                android:textColor="@color/prize_pink_text"
+                android:textColor="@color/white"
                 android:textColorHint="@color/silver_chalice"
                 android:textSize="16sp" />
 
@@ -53,7 +53,7 @@
                 android:fontFamily="sans-serif-medium"
                 android:letterSpacing="0.05"
                 android:text="@string/track_duration_label"
-                android:textColor="@color/wild_strawberry"
+                android:textColor="@color/prize_pink_text"
                 android:textSize="12sp" />
 
             <LinearLayout

--- a/app/src/main/res/layout/fragment_track_associate.xml
+++ b/app/src/main/res/layout/fragment_track_associate.xml
@@ -20,16 +20,6 @@
             android:orientation="vertical"
             android:padding="24dp">
 
-            <!-- Title -->
-            <TextView
-                android:id="@+id/tvAssociateTrackTitle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="32dp"
-                android:fontFamily="sans-serif-black"
-                android:text="@string/associate_track_title"
-                android:textColor="@color/white"
-                android:textSize="24sp" />
 
             <!-- NOMBRE Section -->
             <TextView
@@ -51,7 +41,7 @@
                 android:hint="@string/track_name_placeholder"
                 android:inputType="text"
                 android:paddingHorizontal="16dp"
-                android:textColor="@color/white"
+                android:textColor="@color/prize_pink_text"
                 android:textColorHint="@color/silver_chalice"
                 android:textSize="16sp" />
 
@@ -109,7 +99,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="16dp"
                     android:text=":"
-                    android:textColor="@color/wild_strawberry"
+                    android:textColor="@color/prize_pink_text"
                     android:textSize="28sp"
                     android:textStyle="bold" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,7 +45,7 @@
     <string name="seconds_placeholder">ss</string>
     <string name="cancel_button">CANCELAR</string>
     <string name="associate_button">ASOCIAR</string>
-    <string name="associate_track_title">Asociar track</string>
+    <string name="associate_track_title">Asociar canción</string>
     <string name="info_catalog_title">Información de catálogo</string>
     <string name="info_catalog_desc">Esta canción será asociada directamente a la biblioteca editorial actual. Asegúrate de que los metadatos coincidan con la grabación maestra.</string>
     <string name="min_label">MIN</string>


### PR DESCRIPTION
- Se añaden los modales después de dar click en el botón de asociar, cancelar o volver:

| Asociar | Cancelar | Volver |
|---------|-----------|--------|
| <img height="200" alt="image" src="https://github.com/user-attachments/assets/ae8f8403-e114-440a-b030-781613f2a071" /> | <img height="200" alt="image" src="https://github.com/user-attachments/assets/372deae1-b228-4d37-97f0-9dcc8f8d100c" /> | <img height="200" alt="image" src="https://github.com/user-attachments/assets/90139667-e60f-4558-a723-003f612551aa" />  | 

- Se añade un mensaje confirmando el éxito de la asociación de la canción:

<img height="200" alt="image" src="https://github.com/user-attachments/assets/83a57100-0a25-4efe-8e41-999fa8ea8d8e" /> <p> </p>

- Se realizan unos ligeros ajustes visuales: se elimina el título de la parte superior dado que es el mismo que el de la navegación, y se homogenizan los colores de los campos.
- Se actualizan las pruebas para que corran con los nuevos cambios, y se agregan nuevas para verificar la lógica añadida.

Pruebas corriendo:

<img width="914" height="252" alt="image" src="https://github.com/user-attachments/assets/d7545da5-a6de-4322-bde6-eb52751972f4" />
