### PR TITLE
Modales para crear, cancelar y volver en creación de álbum

### DIFF
--- a/app/src/androidTest/java/com/misw/app/AlbumCreateTest.kt
+++ b/app/src/androidTest/java/com/misw/app/AlbumCreateTest.kt
@@ -113,6 +113,8 @@ class AlbumCreateTest {
 
         onView(withId(R.id.btn_create)).perform(click())
 
+        onView(withText("Sí")).perform(click())
+
         // Check for searchBar to confirm we are back on the list screen
         onView(withId(R.id.searchBar)).check(matches(isDisplayed()))
     }
@@ -122,5 +124,101 @@ class AlbumCreateTest {
         onView(withId(R.id.btn_cancel)).perform(click())
         // Check for searchBar to confirm we are back on the list screen
         onView(withId(R.id.searchBar)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testCancelModalIfFieldsNotEmpty() {
+        val albumName = faker.commerce().productName()
+
+        onView(withId(R.id.et_album_name)).perform(replaceText(albumName), closeSoftKeyboard())
+        onView(withId(R.id.et_cover_url)).perform(replaceText("https://picsum.photos/200"), closeSoftKeyboard())
+        onView(withId(R.id.et_day)).perform(replaceText("15"), closeSoftKeyboard())
+
+        onView(withId(R.id.spinner_month)).perform(click())
+        onData(allOf(`is`(instanceOf(String::class.java)), `is`("Mayo"))).perform(click())
+
+        onView(withId(R.id.et_year)).perform(replaceText("2023"), closeSoftKeyboard())
+        onView(withId(R.id.et_description)).perform(scrollTo(), replaceText(faker.lorem().paragraph()), closeSoftKeyboard())
+
+        onView(withId(R.id.btn_cancel)).perform(click())
+
+        onView(withText("¿Desea cancelar la creación del álbum?")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testCancelModalNoSelected() {
+        val albumName = faker.commerce().productName()
+
+        onView(withId(R.id.et_album_name)).perform(replaceText(albumName), closeSoftKeyboard())
+
+        onView(withId(R.id.btn_cancel)).perform(click())
+
+        onView(withText("No")).perform(click())
+
+        onView(withText("Crear álbum")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testCancelModalYesSelected() {
+        val albumName = faker.commerce().productName()
+
+        onView(withId(R.id.et_album_name)).perform(replaceText(albumName), closeSoftKeyboard())
+
+        onView(withId(R.id.btn_cancel)).perform(click())
+
+        onView(withText("Sí")).perform(click())
+
+        onView(withText("Álbumes")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testAlbumListModalIfFieldsNotEmpty() {
+        val albumName = faker.commerce().productName()
+
+        onView(withId(R.id.et_album_name)).perform(replaceText(albumName), closeSoftKeyboard())
+        onView(withId(R.id.et_cover_url)).perform(replaceText("https://picsum.photos/200"), closeSoftKeyboard())
+        onView(withId(R.id.et_day)).perform(replaceText("15"), closeSoftKeyboard())
+
+        onView(withId(R.id.spinner_month)).perform(click())
+        onData(allOf(`is`(instanceOf(String::class.java)), `is`("Mayo"))).perform(click())
+
+        onView(withId(R.id.et_year)).perform(replaceText("2023"), closeSoftKeyboard())
+        onView(withId(R.id.et_description)).perform(scrollTo(), replaceText(faker.lorem().paragraph()), closeSoftKeyboard())
+
+        onView(withContentDescription(
+            androidx.appcompat.R.string.abc_action_bar_up_description
+        )).perform(click())
+
+        onView(withText("¿Desea volver al listado de álbumes?")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testAlbumListModalNoSelected() {
+        val albumName = faker.commerce().productName()
+
+        onView(withId(R.id.et_album_name)).perform(replaceText(albumName), closeSoftKeyboard())
+
+        onView(withContentDescription(
+            androidx.appcompat.R.string.abc_action_bar_up_description
+        )).perform(click())
+
+        onView(withText("No")).perform(click())
+
+        onView(withText("Crear álbum")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testAlbumListModalYesSelected() {
+        val albumName = faker.commerce().productName()
+
+        onView(withId(R.id.et_album_name)).perform(replaceText(albumName), closeSoftKeyboard())
+
+        onView(withContentDescription(
+            androidx.appcompat.R.string.abc_action_bar_up_description
+        )).perform(click())
+
+        onView(withText("Sí")).perform(click())
+
+        onView(withText("Álbumes")).check(matches(isDisplayed()))
     }
 }

--- a/app/src/main/java/com/misw/app/ui/albums/AlbumCreateFragment.kt
+++ b/app/src/main/java/com/misw/app/ui/albums/AlbumCreateFragment.kt
@@ -2,10 +2,14 @@ package com.misw.app.ui.albums
 
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ArrayAdapter
 import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
+import androidx.appcompat.app.AlertDialog
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -30,6 +34,15 @@ class AlbumCreateFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        setHasOptionsMenu(true)
+
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    handleBack()
+                }
+            })
 
         setupSpinners()
         setupButtons()
@@ -57,20 +70,66 @@ class AlbumCreateFragment : Fragment() {
 
     private fun setupButtons() {
         binding.btnCancel.setOnClickListener {
-            findNavController().navigateUp()
+            val name = binding.etAlbumName.text.toString()
+            val cover = binding.etCoverUrl.text.toString()
+            val description = binding.etDescription.text.toString()
+            val day = binding.etDay.text.toString()
+            val monthIndex = binding.spinnerMonth.selectedItemPosition
+            val year = binding.etYear.text.toString()
+            val genreIndex = binding.spinnerGenre.selectedItemPosition
+            val recordLabelIndex = binding.spinnerRecordLabel.selectedItemPosition
+
+            if (viewModel.areFieldsEmpty(name, cover, description, day, monthIndex, year, genreIndex, recordLabelIndex)) {
+                findNavController().navigateUp()
+            } else {
+                val dialog = AlertDialog.Builder(requireContext())
+                    .setTitle("¿Desea cancelar la creación del álbum?")
+                    .setMessage("Esta acción no se puede deshacer")
+                    .setPositiveButton("Sí") {_, _ ->
+                        findNavController().popBackStack()
+                    }
+                    .setNegativeButton("No", null)
+                    .show()
+                dialog.getButton(AlertDialog.BUTTON_POSITIVE)
+                    .setTextColor(ContextCompat.getColor(requireContext(), R.color.prize_pink_text))
+                dialog.getButton(AlertDialog.BUTTON_NEGATIVE)
+                    .setTextColor(ContextCompat.getColor(requireContext(), R.color.prize_pink_text))
+            }
         }
 
         binding.btnCreate.setOnClickListener {
-            viewModel.createAlbum(
-                name = binding.etAlbumName.text.toString(),
-                cover = binding.etCoverUrl.text.toString(),
-                description = binding.etDescription.text.toString(),
-                day = binding.etDay.text.toString(),
-                monthIndex = binding.spinnerMonth.selectedItemPosition,
-                year = binding.etYear.text.toString(),
-                genre = binding.spinnerGenre.selectedItem?.toString() ?: "",
-                recordLabel = binding.spinnerRecordLabel.selectedItem?.toString() ?: ""
-            )
+            val name = binding.etAlbumName.text.toString()
+            val cover = binding.etCoverUrl.text.toString()
+            val description = binding.etDescription.text.toString()
+            val day = binding.etDay.text.toString()
+            val monthIndex = binding.spinnerMonth.selectedItemPosition
+            val year = binding.etYear.text.toString()
+            val genre = binding.spinnerGenre.selectedItem?.toString() ?: ""
+            val recordLabel = binding.spinnerRecordLabel.selectedItem?.toString() ?: ""
+
+            if (viewModel.validateFields(name, cover, description, day, monthIndex, year, genre, recordLabel)) {
+                val dialog = AlertDialog.Builder(requireContext())
+                    .setTitle("¿Desea crear el álbum ${name}?")
+                    .setMessage("Esta acción no se puede deshacer")
+                    .setPositiveButton("Sí") {_, _ ->
+                        viewModel.createAlbum(
+                            name = binding.etAlbumName.text.toString(),
+                            cover = binding.etCoverUrl.text.toString(),
+                            description = binding.etDescription.text.toString(),
+                            day = binding.etDay.text.toString(),
+                            monthIndex = binding.spinnerMonth.selectedItemPosition,
+                            year = binding.etYear.text.toString(),
+                            genre = binding.spinnerGenre.selectedItem?.toString() ?: "",
+                            recordLabel = binding.spinnerRecordLabel.selectedItem?.toString() ?: ""
+                        )
+                    }
+                    .setNegativeButton("No", null)
+                    .show()
+                dialog.getButton(AlertDialog.BUTTON_POSITIVE)
+                    .setTextColor(ContextCompat.getColor(requireContext(), R.color.prize_pink_text))
+                dialog.getButton(AlertDialog.BUTTON_NEGATIVE)
+                    .setTextColor(ContextCompat.getColor(requireContext(), R.color.prize_pink_text))
+            }
         }
     }
 
@@ -87,6 +146,44 @@ class AlbumCreateFragment : Fragment() {
             error?.let {
                 Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
             }
+        }
+    }
+
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            handleBack()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+
+    private fun handleBack() {
+        val name = binding.etAlbumName.text.toString()
+        val cover = binding.etCoverUrl.text.toString()
+        val description = binding.etDescription.text.toString()
+        val day = binding.etDay.text.toString()
+        val monthIndex = binding.spinnerMonth.selectedItemPosition
+        val year = binding.etYear.text.toString()
+        val genreIndex = binding.spinnerGenre.selectedItemPosition
+        val recordLabelIndex = binding.spinnerRecordLabel.selectedItemPosition
+
+        val fieldsEmpty = viewModel.areFieldsEmpty(name, cover, description, day, monthIndex, year, genreIndex, recordLabelIndex)
+        if (!fieldsEmpty) {
+            val dialog = AlertDialog.Builder(requireContext())
+                .setTitle("¿Desea volver al listado de álbumes?")
+                .setMessage("Esto eliminará el contenido de los campos que haya llenado")
+                .setPositiveButton("Sí") {_, _ ->
+                    findNavController().popBackStack()
+                }
+                .setNegativeButton("No", null)
+                .show()
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE)
+                .setTextColor(ContextCompat.getColor(requireContext(), R.color.prize_pink_text))
+            dialog.getButton(AlertDialog.BUTTON_NEGATIVE)
+                .setTextColor(ContextCompat.getColor(requireContext(), R.color.prize_pink_text))
+        } else {
+            findNavController().popBackStack()
         }
     }
 

--- a/app/src/main/java/com/misw/app/ui/albums/AlbumListFragment.kt
+++ b/app/src/main/java/com/misw/app/ui/albums/AlbumListFragment.kt
@@ -139,8 +139,12 @@ class AlbumListFragment : Fragment() {
 
         viewModel.isLoading.observe(viewLifecycleOwner) { isLoading ->
             binding.pbAlbumList.visibility = if (isLoading) View.VISIBLE else View.GONE
-            if (isLoading) {
-                binding.llEmptyState.visibility = View.GONE
+
+            if (!isLoading) {
+                updateUIState(
+                    viewModel.albums.value ?: emptyList<Any>(),
+                    viewModel.error.value
+                )
             }
         }
     }

--- a/app/src/main/java/com/misw/app/ui/albums/AlbumListFragment.kt
+++ b/app/src/main/java/com/misw/app/ui/albums/AlbumListFragment.kt
@@ -146,6 +146,8 @@ class AlbumListFragment : Fragment() {
     }
 
     private fun updateUIState(albums: List<*>, error: String?) {
+        if (viewModel.isLoading.value == true) return
+
         when {
             error != null -> {
                 binding.llEmptyState.visibility = View.VISIBLE

--- a/app/src/main/java/com/misw/app/viewmodel/AlbumCreateViewModel.kt
+++ b/app/src/main/java/com/misw/app/viewmodel/AlbumCreateViewModel.kt
@@ -92,7 +92,7 @@ class AlbumCreateViewModel(application: Application) : AndroidViewModel(applicat
                 _isSuccess.value = true
             } catch (e: Exception) {
                 Log.e("AlbumCreateViewModel", "Error al crear el álbum", e.cause)
-                _error.value = "Error al crear el álbum"
+                _error.value = "Error al crear el álbum: ${e.message}"
             } finally {
                 _isLoading.value = false
             }

--- a/app/src/main/java/com/misw/app/viewmodel/AlbumCreateViewModel.kt
+++ b/app/src/main/java/com/misw/app/viewmodel/AlbumCreateViewModel.kt
@@ -53,6 +53,13 @@ class AlbumCreateViewModel(application: Application) : AndroidViewModel(applicat
     private val _recordLabelError = MutableLiveData<String?>()
     val recordLabelError: LiveData<String?> get() = _recordLabelError
 
+    fun areFieldsEmpty(
+        name: String, cover: String, description:String, day: String, monthIndex: Int, year: String, genreIndex: Int, recordLabelIndex: Int
+    ): Boolean {
+        return name.isBlank() and cover.isBlank() and description.isBlank() and
+                day.isBlank() and (monthIndex == 0) and year.isBlank() and (genreIndex == 0) and (recordLabelIndex == 0)
+    }
+
     fun createAlbum(
         name: String,
         cover: String,
@@ -63,9 +70,6 @@ class AlbumCreateViewModel(application: Application) : AndroidViewModel(applicat
         genre: String,
         recordLabel: String
     ) {
-        if (!validateFields(name, cover, description, day, monthIndex, year, genre, recordLabel)) {
-            return
-        }
 
         viewModelScope.launch {
             _isLoading.value = true
@@ -95,7 +99,7 @@ class AlbumCreateViewModel(application: Application) : AndroidViewModel(applicat
         }
     }
 
-    private fun validateFields(
+    fun validateFields(
         name: String,
         cover: String,
         description: String,

--- a/app/src/main/java/com/misw/app/viewmodel/AlbumViewModel.kt
+++ b/app/src/main/java/com/misw/app/viewmodel/AlbumViewModel.kt
@@ -31,10 +31,6 @@ class AlbumViewModel(application: Application) : AndroidViewModel(application) {
     private val _isLoading = MutableLiveData<Boolean>()
     val isLoading: LiveData<Boolean> get() = _isLoading
 
-    init {
-        fetchAlbums()
-    }
-
     fun fetchAlbums() {
         viewModelScope.launch {
             _isLoading.value = true


### PR DESCRIPTION
- Se añaden los modales después de dar click en el botón de crear, cancelar o volver:

| Crear | Cancelar | Volver |
|---------|-----------|--------|
| <img height="200" alt="image" src="https://github.com/user-attachments/assets/e0a4dc10-d9e0-4127-8127-d4593bb29b02" /> | <img height="200" alt="image" src="https://github.com/user-attachments/assets/3d16e3b2-8225-4ae6-a78a-3c6084073c1e" /> | <img height="200" alt="image" src="https://github.com/user-attachments/assets/e653cdac-8527-4b7d-8875-a9fd1a3f793c" />  | 

- Se actualizan las pruebas existentes y se añaden nuevas para funcionar con la lógica añadida

<img width="853" height="324" alt="image" src="https://github.com/user-attachments/assets/98b9625c-81cc-4fce-ae77-04ac8acae91e" />
