### PR TITLE
Fix de sobrelamapiento de barra de navegacion

### DIFF
--- a/app/src/main/java/com/misw/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/misw/app/ui/MainActivity.kt
@@ -2,6 +2,7 @@ package com.misw.app.ui
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowCompat
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupActionBarWithNavController
 import com.misw.app.R
@@ -11,6 +12,8 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        WindowCompat.setDecorFitsSystemWindows(window, true)
 
         val binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,6 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     tools:context=".ui.MainActivity">
 
     <com.google.android.material.appbar.AppBarLayout

--- a/app/src/main/res/layout/fragment_album_create.xml
+++ b/app/src/main/res/layout/fragment_album_create.xml
@@ -18,7 +18,9 @@
         <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_marginBottom="16dp"
+            android:scrollbars="vertical"
+            android:scrollbarStyle="insideOverlay"
+            android:fadeScrollbars="false"
             app:layout_constraintBottom_toTopOf="@id/ll_buttons"
             app:layout_constraintTop_toTopOf="parent">
 

--- a/app/src/main/res/layout/fragment_track_associate.xml
+++ b/app/src/main/res/layout/fragment_track_associate.xml
@@ -28,7 +28,7 @@
                 android:fontFamily="sans-serif-medium"
                 android:letterSpacing="0.05"
                 android:text="@string/track_name_label"
-                android:textColor="@color/prize_pink_text"
+                android:textColor="@color/silver_chalice"
                 android:textSize="12sp" />
 
             <EditText
@@ -54,7 +54,7 @@
                 android:fontFamily="sans-serif-medium"
                 android:letterSpacing="0.05"
                 android:text="@string/track_duration_label"
-                android:textColor="@color/prize_pink_text"
+                android:textColor="@color/silver_chalice"
                 android:textSize="12sp" />
 
             <LinearLayout


### PR DESCRIPTION
- Se corrige la ventana de la app para que la parte de abajo no se sobrelape con la barra de navegación del celular.
- Se agrega una barra de scroll vertical en crear álbum para que sea más claro que hay más campos al final.

<img height="300" alt="Captura de pantalla 2026-05-23 153815" src="https://github.com/user-attachments/assets/ebad4092-b673-472c-8c8e-03755d7192c6" />

- Se cambia el color de los labels de asociar track para que coincidan con los de crear álbum.

<img height="300" alt="image" src="https://github.com/user-attachments/assets/790a06e9-ccff-4d46-8f89-4f37f3458447" />

